### PR TITLE
Fix relative path being checked against absolute path

### DIFF
--- a/hotswap/hotswap.py
+++ b/hotswap/hotswap.py
@@ -40,6 +40,7 @@ def override(a: object, b: object):
                 delattr(a, x)
             except:
                 pass
+
     for x in dir(b):
         if x.startswith("__"):
             continue
@@ -60,15 +61,22 @@ def module_from_path(path: Path) -> Optional[ModuleType]:
     for mod in sys.modules.values():
         if not hasattr(mod, "__file__"):
             continue
+
         if mod.__file__ is None:
             continue
-        if Path(mod.__file__) == path:
-            return mod
+
+        if Path(mod.__file__).absolute() != path:
+            continue
+
+        return mod
+
+    return None
 
 
-def hotswap(path: Path):
+def hotswap(path: Path) -> None:
     if not path.exists():
         return
+
     if not path.is_file():
         return
 


### PR DESCRIPTION
hotswap isn't working when running it with a relative path, and changing the sources in the relative path, since it checks if the paths are equal and passes the absolute path, however in the module definitions it's stored as local. So running this isn't working without this patch.

```sh
python simpletest.py
```